### PR TITLE
Improve mobile responsiveness using Tailwind CSS responsive utilities

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -8,3 +8,18 @@
  *
  * Consider organizing styles into separate files for maintainability.
  */
+
+/* Prevent iOS zoom on input focus - this is one of the few cases where custom CSS is needed */
+@media (max-width: 768px) {
+  input[type="text"],
+  input[type="email"],
+  input[type="password"],
+  input[type="number"],
+  input[type="tel"],
+  input[type="url"],
+  input[type="search"],
+  textarea,
+  select {
+    font-size: 16px;
+  }
+}

--- a/app/javascript/controllers/mobile_menu_controller.js
+++ b/app/javascript/controllers/mobile_menu_controller.js
@@ -3,15 +3,7 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["menu"]
   
-  connect() {
-    // メニューボタンにイベントリスナーを追加
-    const menuButton = document.querySelector('.mobile-menu-button')
-    const mobileMenu = document.querySelector('.mobile-menu')
-    
-    if (menuButton && mobileMenu) {
-      menuButton.addEventListener('click', () => {
-        mobileMenu.classList.toggle('hidden')
-      })
-    }
+  toggle() {
+    this.menuTarget.classList.toggle('hidden')
   }
 }

--- a/app/javascript/controllers/mobile_menu_controller.js
+++ b/app/javascript/controllers/mobile_menu_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["menu"]
+  
+  connect() {
+    // メニューボタンにイベントリスナーを追加
+    const menuButton = document.querySelector('.mobile-menu-button')
+    const mobileMenu = document.querySelector('.mobile-menu')
+    
+    if (menuButton && mobileMenu) {
+      menuButton.addEventListener('click', () => {
+        mobileMenu.classList.toggle('hidden')
+      })
+    }
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -70,11 +70,11 @@
           <% if user_signed_in? %>
             <div class="space-y-2">
               <%= link_to t('navigation.products'), products_path, 
-                  class: "block px-3 py-2 rounded text-blue-600 hover:bg-gray-100 font-medium #{'bg-gray-100 font-bold' if controller_name == 'products'}" %>
+                  class: "block px-3 py-2 rounded text-blue-600 hover:bg-gray-100 font-medium text-sm md:text-base #{'bg-gray-100 font-bold' if controller_name == 'products'}" %>
               <%= link_to t('navigation.materials'), materials_path, 
-                  class: "block px-3 py-2 rounded text-blue-600 hover:bg-gray-100 font-medium #{'bg-gray-100 font-bold' if controller_name == 'materials'}" %>
+                  class: "block px-3 py-2 rounded text-blue-600 hover:bg-gray-100 font-medium text-sm md:text-base #{'bg-gray-100 font-bold' if controller_name == 'materials'}" %>
               <%= link_to t('navigation.settings'), edit_user_registration_path, 
-                  class: "block px-3 py-2 rounded text-blue-600 hover:bg-gray-100 font-medium #{'bg-gray-100 font-bold' if controller_name == 'registrations'}" %>
+                  class: "block px-3 py-2 rounded text-blue-600 hover:bg-gray-100 font-medium text-sm md:text-base #{'bg-gray-100 font-bold' if controller_name == 'registrations'}" %>
               <div class="pt-2 mt-2 border-t">
                 <div class="text-sm text-gray-600 px-3 py-1"><%= current_user.email %></div>
                 <%= link_to t('navigation.logout'), destroy_user_session_path, 
@@ -85,9 +85,9 @@
           <% else %>
             <div class="space-y-2">
               <%= link_to t('navigation.login'), new_user_session_path, 
-                  class: "block bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded text-center" %>
+                  class: "block bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded text-center text-sm md:text-base" %>
               <%= link_to t('navigation.sign_up'), new_user_registration_path, 
-                  class: "block bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded text-center" %>
+                  class: "block bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded text-center text-sm md:text-base" %>
             </div>
           <% end %>
         </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,15 +22,16 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body class="bg-gray-100">
+  <body class="bg-gray-100" data-controller="mobile-menu">
     <nav class="bg-white shadow mb-8">
-      <div class="container mx-auto px-6 py-3">
+      <div class="container mx-auto px-4 py-3">
         <div class="flex justify-between items-center">
           <div class="text-xl font-semibold text-gray-700">
             <%= link_to "CostCalc", root_path %>
           </div>
           
-          <div class="flex items-center space-x-4">
+          <!-- Desktop Navigation -->
+          <div class="hidden md:flex items-center space-x-4">
             <% if user_signed_in? %>
               <!-- Navigation links -->
               <nav class="flex space-x-4 mr-8">
@@ -47,14 +48,48 @@
               </span>
               <%= link_to t('navigation.logout'), destroy_user_session_path, 
                   data: { turbo_method: :delete }, 
-                  class: "bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded" %>
+                  class: "bg-red-500 hover:bg-red-700 text-white font-bold py-1 px-2 md:py-2 md:px-4 rounded text-sm md:text-base" %>
             <% else %>
               <%= link_to t('navigation.login'), new_user_session_path, 
-                  class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" %>
+                  class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-1 px-2 md:py-2 md:px-4 rounded text-sm md:text-base" %>
               <%= link_to t('navigation.sign_up'), new_user_registration_path, 
-                  class: "bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded" %>
+                  class: "bg-green-500 hover:bg-green-700 text-white font-bold py-1 px-2 md:py-2 md:px-4 rounded text-sm md:text-base" %>
             <% end %>
           </div>
+          
+          <!-- Mobile menu button -->
+          <button type="button" class="md:hidden mobile-menu-button" aria-label="Menu">
+            <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-16 6h16"></path>
+            </svg>
+          </button>
+        </div>
+        
+        <!-- Mobile Navigation -->
+        <div class="md:hidden mobile-menu hidden mt-3 pt-3 border-t">
+          <% if user_signed_in? %>
+            <div class="space-y-2">
+              <%= link_to t('navigation.products'), products_path, 
+                  class: "block px-3 py-2 rounded text-blue-600 hover:bg-gray-100 font-medium #{'bg-gray-100 font-bold' if controller_name == 'products'}" %>
+              <%= link_to t('navigation.materials'), materials_path, 
+                  class: "block px-3 py-2 rounded text-blue-600 hover:bg-gray-100 font-medium #{'bg-gray-100 font-bold' if controller_name == 'materials'}" %>
+              <%= link_to t('navigation.settings'), edit_user_registration_path, 
+                  class: "block px-3 py-2 rounded text-blue-600 hover:bg-gray-100 font-medium #{'bg-gray-100 font-bold' if controller_name == 'registrations'}" %>
+              <div class="pt-2 mt-2 border-t">
+                <div class="text-sm text-gray-600 px-3 py-1"><%= current_user.email %></div>
+                <%= link_to t('navigation.logout'), destroy_user_session_path, 
+                    data: { turbo_method: :delete }, 
+                    class: "block mt-2 bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded text-center" %>
+              </div>
+            </div>
+          <% else %>
+            <div class="space-y-2">
+              <%= link_to t('navigation.login'), new_user_session_path, 
+                  class: "block bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded text-center" %>
+              <%= link_to t('navigation.sign_up'), new_user_registration_path, 
+                  class: "block bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded text-center" %>
+            </div>
+          <% end %>
         </div>
       </div>
     </nav>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -58,7 +58,7 @@
           </div>
           
           <!-- Mobile menu button -->
-          <button type="button" class="md:hidden mobile-menu-button" aria-label="Menu">
+          <button type="button" class="md:hidden" aria-label="Menu" data-action="click->mobile-menu#toggle">
             <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-16 6h16"></path>
             </svg>
@@ -66,7 +66,7 @@
         </div>
         
         <!-- Mobile Navigation -->
-        <div class="md:hidden mobile-menu hidden mt-3 pt-3 border-t">
+        <div class="md:hidden hidden mt-3 pt-3 border-t" data-mobile-menu-target="menu">
           <% if user_signed_in? %>
             <div class="space-y-2">
               <%= link_to t('navigation.products'), products_path, 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -58,7 +58,7 @@
           </div>
           
           <!-- Mobile menu button -->
-          <button type="button" class="md:hidden" aria-label="Menu" data-action="click->mobile-menu#toggle">
+          <button type="button" class="md:hidden" aria-label="Menu" aria-controls="mobile-menu" data-action="click->mobile-menu#toggle">
             <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-16 6h16"></path>
             </svg>

--- a/app/views/materials/edit.html.erb
+++ b/app/views/materials/edit.html.erb
@@ -65,13 +65,13 @@
       </div>
 
       <!-- アクションボタン -->
-      <div class="flex space-x-4 pt-4 border-t">
-        <%= form.submit t('common.update'), class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded cursor-pointer" %>
+      <div class="grid grid-cols-2 md:flex gap-2 md:space-x-4 pt-4 border-t">
+        <%= form.submit t('common.update'), class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-3 md:px-4 rounded cursor-pointer text-sm md:text-base text-center" %>
         <%= link_to t('common.cancel'), materials_path, 
-            class: "bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded" %>
+            class: "bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-3 md:px-4 rounded text-sm md:text-base text-center" %>
         <%= link_to t('common.delete'), material_path(@material_form.material), 
             data: { turbo_method: :delete, turbo_confirm: t('common.confirm_delete') }, 
-            class: "bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded" %>
+            class: "col-span-2 md:col-span-1 bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-3 md:px-4 rounded text-sm md:text-base text-center" %>
       </div>
     <% end %>
   </div>

--- a/app/views/materials/index.html.erb
+++ b/app/views/materials/index.html.erb
@@ -2,7 +2,7 @@
   <div class="flex justify-between items-center mb-6">
     <h1 class="text-3xl font-bold"><%= t('materials.title') %></h1>
     <%= link_to t('materials.add_material'), new_material_path, 
-        class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" %>
+        class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-1.5 px-3 md:py-2 md:px-4 rounded text-sm md:text-base" %>
   </div>
   
   <hr class="mb-6" />

--- a/app/views/materials/new.html.erb
+++ b/app/views/materials/new.html.erb
@@ -72,10 +72,10 @@
       </div>
 
       <!-- アクションボタン -->
-      <div class="flex space-x-4 pt-4 border-t">
-        <%= form.submit t('common.create'), class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded cursor-pointer" %>
+      <div class="flex gap-4 pt-4 border-t">
+        <%= form.submit t('common.create'), class: "flex-1 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded cursor-pointer text-sm md:text-base text-center" %>
         <%= link_to t('common.cancel'), materials_path, 
-            class: "bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded" %>
+            class: "flex-1 bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded text-sm md:text-base text-center" %>
       </div>
     <% end %>
   </div>

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -45,12 +45,12 @@
         
         <div data-product-form-target="ingredientsContainer">
           <% @product_form.product_ingredients.each_with_index do |ingredient_form, index| %>
-            <div class="ingredient-row grid grid-cols-12 gap-2 mb-3 p-3 bg-gray-50 rounded">
+            <div class="ingredient-row grid grid-cols-1 md:grid-cols-12 gap-2 mb-3 p-3 bg-gray-50 rounded">
               <input type="hidden" name="product_form[product_ingredients_attributes][<%= index %>][id]" value="<%= ingredient_form.id %>" />
               <input type="hidden" name="product_form[product_ingredients_attributes][<%= index %>][delete]" value="0" class="destroy-input" />
               
               <!-- 材料選択 -->
-              <div class="col-span-4">
+              <div class="col-span-1 md:col-span-4">
                 <label class="block text-xs text-gray-600 mb-1"><%= t('products.material_name') %></label>
                 <input type="hidden" name="product_form[product_ingredients_attributes][<%= index %>][material_id]" value="<%= ingredient_form.material_id %>" class="material-id-input" />
                 <input type="text" 
@@ -70,7 +70,7 @@
               </div>
               
               <!-- 分量 -->
-              <div class="col-span-2">
+              <div class="col-span-1 md:col-span-2">
                 <label class="block text-xs text-gray-600 mb-1"><%= t('products.amount') %></label>
                 <input type="number" 
                        name="product_form[product_ingredients_attributes][<%= index %>][ingredient_count]"
@@ -81,7 +81,7 @@
               </div>
               
               <!-- 単位（材料に応じて絞り込み）-->
-              <div class="col-span-3">
+              <div class="col-span-1 md:col-span-3">
                 <label class="block text-xs text-gray-600 mb-1"><%= t('materials.unit') %></label>
                 <select name="product_form[product_ingredients_attributes][<%= index %>][unit_id]"
                         class="unit-select w-full px-2 py-1 border border-gray-300 rounded text-sm"
@@ -99,10 +99,10 @@
               </div>
               
               <!-- 削除ボタン -->
-              <div class="col-span-1 flex items-end">
+              <div class="col-span-1 md:col-span-2 justify-end flex items-end">
                 <button type="button" 
                         data-action="click->product-form#removeIngredient"
-                        class="bg-red-500 hover:bg-red-700 text-white font-bold py-1 px-2 rounded text-xs w-full">
+                        class="bg-red-500 hover:bg-red-700 text-white font-bold py-1 px-2 rounded text-xs">
                   <%= t('common.delete') %>
                 </button>
               </div>
@@ -121,25 +121,25 @@
       </div>
 
       <!-- アクションボタン -->
-      <div class="flex space-x-4 pt-4 border-t">
-        <%= form.submit t('common.update'), class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" %>
+      <div class="grid grid-cols-2 md:flex gap-2 md:space-x-4 pt-4 border-t">
+        <%= form.submit t('common.update'), class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-3 md:px-4 rounded text-sm md:text-base text-center" %>
         <%= link_to t('common.details'), product_path(@product_form.product), 
-            class: "bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded" %>
+            class: "bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-3 md:px-4 rounded text-sm md:text-base text-center" %>
         <%= link_to t('common.cancel'), products_path(anchor: "product-#{@product_form.product.id}"), 
-            class: "bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded" %>
+            class: "bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-3 md:px-4 rounded text-sm md:text-base text-center" %>
         <%= link_to t('common.delete'), product_path(@product_form.product), 
             data: { turbo_method: :delete, turbo_confirm: t('common.confirm_delete_really') }, 
-            class: "bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded" %>
+            class: "bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-3 md:px-4 rounded text-sm md:text-base text-center" %>
       </div>
       
       <!-- Template for new ingredients -->
       <template data-product-form-target="ingredientTemplate">
-        <div class="ingredient-row grid grid-cols-12 gap-2 mb-3 p-3 bg-gray-50 rounded">
+        <div class="ingredient-row grid grid-cols-1 md:grid-cols-12 gap-2 mb-3 p-3 bg-gray-50 rounded">
           <input type="hidden" name="product_form[product_ingredients_attributes][__INDEX__][id]" value="" />
           <input type="hidden" name="product_form[product_ingredients_attributes][__INDEX__][delete]" value="0" class="destroy-input" />
           
           <!-- 材料選択 -->
-          <div class="col-span-4">
+          <div class="col-span-1 md:col-span-4">
             <label class="block text-xs text-gray-600 mb-1"><%= t('products.material_name') %></label>
             <input type="hidden" name="product_form[product_ingredients_attributes][__INDEX__][material_id]" value="" class="material-id-input" />
             <input type="text" 
@@ -158,7 +158,7 @@
           </div>
           
           <!-- 分量 -->
-          <div class="col-span-2">
+          <div class="col-span-1 md:col-span-2">
             <label class="block text-xs text-gray-600 mb-1"><%= t('products.amount') %></label>
             <input type="number" 
                    name="product_form[product_ingredients_attributes][__INDEX__][ingredient_count]"
@@ -168,7 +168,7 @@
           </div>
           
           <!-- 単位 -->
-          <div class="col-span-3">
+          <div class="col-span-1 md:col-span-3">
             <label class="block text-xs text-gray-600 mb-1"><%= t('materials.unit') %></label>
             <select name="product_form[product_ingredients_attributes][__INDEX__][unit_id]"
                     class="unit-select w-full px-2 py-1 border border-gray-300 rounded text-sm"
@@ -178,10 +178,10 @@
           </div>
           
           <!-- 削除ボタン -->
-          <div class="col-span-1 flex items-end">
+          <div class="col-span-1 md:col-span-2 justify-end flex items-end">
             <button type="button" 
                     data-action="click->product-form#removeIngredient"
-                    class="bg-red-500 hover:bg-red-700 text-white font-bold py-1 px-2 rounded text-xs w-full">
+                    class="bg-red-500 hover:bg-red-700 text-white font-bold py-1 px-2 rounded text-xs">
               <%= t('common.delete') %>
             </button>
           </div>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -2,7 +2,7 @@
   <div class="flex justify-between items-center mb-6">
     <h1 class="text-3xl font-bold"><%= t('products.title') %></h1>
     <%= link_to t('products.add_product'), new_product_path, 
-        class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" %>
+        class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-1.5 px-3 md:py-2 md:px-4 rounded text-sm md:text-base" %>
   </div>
   
   <hr class="mb-6" />

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -48,7 +48,7 @@
             <input type="hidden" name="product_form[product_ingredients_attributes][0][delete]" value="0" class="destroy-input" />
             
             <!-- 材料選択 -->
-            <div class="col-span-1 md:col-span-4">
+            <div class="col-span-1 md:col-span-3">
               <label class="block text-xs text-gray-600 mb-1"><%= t('products.material_name') %></label>
               <input type="hidden" name="product_form[product_ingredients_attributes][0][material_id]" value="" class="material-id-input" />
               <input type="text" 

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -43,12 +43,12 @@
         
         <div data-product-form-target="ingredientsContainer">
           <!-- Start with one empty ingredient -->
-          <div class="ingredient-row grid grid-cols-12 gap-2 mb-3 p-3 bg-gray-50 rounded">
+          <div class="ingredient-row grid grid-cols-1 md:grid-cols-12 gap-2 mb-3 p-3 bg-gray-50 rounded">
             <input type="hidden" name="product_form[product_ingredients_attributes][0][id]" value="" />
             <input type="hidden" name="product_form[product_ingredients_attributes][0][delete]" value="0" class="destroy-input" />
             
             <!-- 材料選択 -->
-            <div class="col-span-4">
+            <div class="col-span-1 md:col-span-4">
               <label class="block text-xs text-gray-600 mb-1"><%= t('products.material_name') %></label>
               <input type="hidden" name="product_form[product_ingredients_attributes][0][material_id]" value="" class="material-id-input" />
               <input type="text" 
@@ -67,7 +67,7 @@
             </div>
             
             <!-- 分量 -->
-            <div class="col-span-2">
+            <div class="col-span-1 md:col-span-2">
               <label class="block text-xs text-gray-600 mb-1"><%= t('products.quantity') %></label>
               <input type="number" 
                      name="product_form[product_ingredients_attributes][0][ingredient_count]"
@@ -77,7 +77,7 @@
             </div>
             
             <!-- 単位（材料に応じて絞り込み）-->
-            <div class="col-span-3">
+            <div class="col-span-1 md:col-span-3">
               <label class="block text-xs text-gray-600 mb-1"><%= t('materials.unit') %></label>
               <select name="product_form[product_ingredients_attributes][0][unit_id]"
                       class="unit-select w-full px-2 py-1 border border-gray-300 rounded text-sm"
@@ -87,10 +87,10 @@
             </div>
             
             <!-- <%= t('common.delete') %>ボタン -->
-            <div class="col-span-1 flex items-end">
+            <div class="col-span-1 flex items-end md:col-span-2 justify-end">
               <button type="button" 
                       data-action="click->product-form#removeIngredient"
-                      class="bg-red-500 hover:bg-red-700 text-white font-bold py-1 px-2 rounded text-xs w-full">
+                      class="bg-red-500 hover:bg-red-700 text-white font-bold py-1 px-2 rounded text-xs">
                 <%= t('common.delete') %>
               </button>
             </div>
@@ -108,20 +108,20 @@
       </div>
 
       <!-- アクションボタン -->
-      <div class="flex space-x-4 pt-4 border-t">
-        <%= form.submit t('common.create'), class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" %>
+      <div class="flex gap-4 pt-4 border-t">
+        <%= form.submit t('common.create'), class: "flex-1 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded text-sm md:text-base text-center" %>
         <%= link_to t('common.cancel'), products_path, 
-            class: "bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded" %>
+            class: "flex-1 bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded text-sm md:text-base text-center" %>
       </div>
       
       <!-- Template for new ingredients -->
       <template data-product-form-target="ingredientTemplate">
-        <div class="ingredient-row grid grid-cols-12 gap-2 mb-3 p-3 bg-gray-50 rounded">
+        <div class="ingredient-row grid grid-cols-1 md:grid-cols-12 gap-2 mb-3 p-3 bg-gray-50 rounded">
           <input type="hidden" name="product_form[product_ingredients_attributes][__INDEX__][id]" value="" />
           <input type="hidden" name="product_form[product_ingredients_attributes][__INDEX__][delete]" value="0" class="destroy-input" />
           
           <!-- 材料選択 -->
-          <div class="col-span-4">
+          <div class="col-span-1 md:col-span-4">
             <label class="block text-xs text-gray-600 mb-1"><%= t('products.material_name') %></label>
             <input type="hidden" name="product_form[product_ingredients_attributes][__INDEX__][material_id]" value="" class="material-id-input" />
             <input type="text" 
@@ -140,7 +140,7 @@
           </div>
           
           <!-- 分量 -->
-          <div class="col-span-2">
+          <div class="col-span-1 md:col-span-2">
             <label class="block text-xs text-gray-600 mb-1"><%= t('products.quantity') %></label>
             <input type="number" 
                    name="product_form[product_ingredients_attributes][__INDEX__][ingredient_count]"
@@ -150,7 +150,7 @@
           </div>
           
           <!-- 単位 -->
-          <div class="col-span-3">
+          <div class="col-span-1 md:col-span-3">
             <label class="block text-xs text-gray-600 mb-1"><%= t('materials.unit') %></label>
             <select name="product_form[product_ingredients_attributes][__INDEX__][unit_id]"
                     class="unit-select w-full px-2 py-1 border border-gray-300 rounded text-sm"
@@ -160,10 +160,10 @@
           </div>
           
           <!-- <%= t('common.delete') %>ボタン -->
-          <div class="col-span-1 flex items-end">
+          <div class="col-span-1 flex items-end md:col-span-2 justify-end">
             <button type="button" 
                     data-action="click->product-form#removeIngredient"
-                    class="bg-red-500 hover:bg-red-700 text-white font-bold py-1 px-2 rounded text-xs w-full">
+                    class="bg-red-500 hover:bg-red-700 text-white font-bold py-1 px-2 rounded text-xs">
               <%= t('common.delete') %>
             </button>
           </div>


### PR DESCRIPTION
- Remove unnecessary mobile.css with \!important overrides
- Add minimal custom CSS only for iOS zoom prevention (16px font-size)
- Update form layouts to use responsive grid classes (grid-cols-1 md:grid-cols-12)
- Implement proper responsive button layouts:
  - Grid layout for edit forms (2x2 on mobile, flex on desktop)
  - Flex layout for create forms (equal width buttons)
- Add responsive text sizing (text-sm md:text-base)
- Use Tailwind utilities instead of custom CSS for better maintainability
- Fix bottom button layouts to prevent overcrowding on mobile screens

This follows Tailwind CSS best practices and eliminates the need for complex CSS overrides while providing excellent mobile experience.